### PR TITLE
Refactor metric initialization to use structs

### DIFF
--- a/sources/procfs.go
+++ b/sources/procfs.go
@@ -65,6 +65,12 @@ type lustreBRWMetric struct {
 	value     string
 }
 
+type lustreHelpStruct struct {
+	filename string
+	promName string // Name to be used in Prometheus
+	helpText string
+}
+
 func init() {
 	Factories["procfs"] = newLustreSource
 }
@@ -85,47 +91,47 @@ func newLustreProcMetric(name string, source string, path string, helpText strin
 }
 
 func (s *lustreSource) generateOSTMetricTemplates() error {
-	metricMap := map[string]map[string]string{
+	metricMap := map[string][]lustreHelpStruct{
 		"obdfilter/*": {
-			"blocksize":            "Filesystem block size in bytes",
-			"brw_size":             "Block read/write size in bytes",
-			"brw_stats":            "A collection of block read/write statistics",
-			"degraded":             "Binary indicator as to whether or not the pool is degraded - 0 for not degraded, 1 for degraded",
-			"filesfree":            "The number of inodes (objects) available",
-			"filestotal":           "The maximum number of inodes (objects) the filesystem can hold",
-			"grant_compat_disable": "Binary indicator as to whether clients with OBD_CONNECT_GRANT_PARAM setting will be granted space",
-			"grant_precreate":      "Maximum space in bytes that clients can preallocate for objects",
-			"job_cleanup_interval": "Interval in seconds between cleanup of tuning statistics",
-			"job_stats":            "A collection of read/write statistics listed by jobid",
-			"kbytesavail":          "Number of kilobytes readily available in the pool",
-			"kbytesfree":           "Number of kilobytes allocated to the pool",
-			"kbytestotal":          "Capacity of the pool in kilobytes",
-			"lfsck_speed_limit":    "Maximum operations per second LFSCK (Lustre filesystem verification) can run",
-			"num_exports":          "Total number of times the pool has been exported",
-			"precreate_batch":      "Maximum number of objects that can be included in a single transaction",
-			"recovery_time_hard":   "Maximum timeout 'recover_time_soft' can increment to for a single server",
-			"recovery_time_soft":   "Duration in seconds for a client to attempt to reconnect after a crash (automatically incremented if servers are still in an error state)",
-			"soft_sync_limit":      "Number of RPCs necessary before triggering a sync",
-			"stats":                "A collection of statistics specific to Lustre",
-			"sync_journal":         "Binary indicator as to whether or not the journal is set for asynchronous commits",
-			"tot_dirty":            "Total number of exports that have been marked dirty",
-			"tot_granted":          "Total number of exports that have been marked granted",
-			"tot_pending":          "Total number of exports that have been marked pending",
+			{"blocksize", "blocksize", "Filesystem block size in bytes"},
+			{"brw_size", "brw_size", "Block read/write size in bytes"},
+			{"brw_stats", "brw_stats", "A collection of block read/write statistics"},
+			{"degraded", "degraded", "Binary indicator as to whether or not the pool is degraded - 0 for not degraded, 1 for degraded"},
+			{"filesfree", "filesfree", "The number of inodes (objects) available"},
+			{"filestotal", "filestotal", "The maximum number of inodes (objects) the filesystem can hold"},
+			{"grant_compat_disable", "grant_compat_disable", "Binary indicator as to whether clients with OBD_CONNECT_GRANT_PARAM setting will be granted space"},
+			{"grant_precreate", "grant_precreate", "Maximum space in bytes that clients can preallocate for objects"},
+			{"job_cleanup_interval", "job_cleanup_interval", "Interval in seconds between cleanup of tuning statistics"},
+			{"job_stats", "job_stats", "A collection of read/write statistics listed by jobid"},
+			{"kbytesavail", "kbytesavail", "Number of kilobytes readily available in the pool"},
+			{"kbytesfree", "kbytesfree", "Number of kilobytes allocated to the pool"},
+			{"kbytestotal", "kbytestotal", "Capacity of the pool in kilobytes"},
+			{"lfsck_speed_limit", "lfsck_speed_limit", "Maximum operations per second LFSCK (Lustre filesystem verification) can run"},
+			{"num_exports", "num_exports", "Total number of times the pool has been exported"},
+			{"precreate_batch", "precreate_batch", "Maximum number of objects that can be included in a single transaction"},
+			{"recovery_time_hard", "recovery_time_hard", "Maximum timeout 'recover_time_soft' can increment to for a single server"},
+			{"recovery_time_soft", "recovery_time_soft", "Duration in seconds for a client to attempt to reconnect after a crash (automatically incremented if servers are still in an error state)"},
+			{"soft_sync_limit", "soft_sync_limit", "Number of RPCs necessary before triggering a sync"},
+			{"stats", "stats", "A collection of statistics specific to Lustre"},
+			{"sync_journal", "sync_journal", "Binary indicator as to whether or not the journal is set for asynchronous commits"},
+			{"tot_dirty", "tot_dirty", "Total number of exports that have been marked dirty"},
+			{"tot_granted", "tot_granted", "Total number of exports that have been marked granted"},
+			{"tot_pending", "tot_pending", "Total number of exports that have been marked pending"},
 		},
 		"ldlm/namespaces/filter-*": {
-			"lock_count":         "Number of locks",
-			"lock_timeouts":      "Number of lock timeouts",
-			"contended_locks":    "Number of contended locks",
-			"contention_seconds": "Time in seconds during which locks were contended",
-			"pool/granted":       "Number of granted locks",
-			"pool/grant_rate":    "Lock grant rate",
-			"pool/cancel_rate":   "Lock cancel rate",
-			"pool/grant_speed":   "Lock grant speed",
+			{"lock_count", "lock_count", "Number of locks"},
+			{"lock_timeouts", "lock_timeouts", "Number of lock timeouts"},
+			{"contended_locks", "contended_locks", "Number of contended locks"},
+			{"contention_seconds", "contention_seconds", "Time in seconds during which locks were contended"},
+			{"pool/granted", "granted", "Number of granted locks"},
+			{"pool/grant_rate", "grant_rate", "Lock grant rate"},
+			{"pool/cancel_rate", "cancel_rate", "Lock cancel rate"},
+			{"pool/grant_speed", "grant_speed", "Lock grant speed"},
 		},
 	}
 	for path := range metricMap {
-		for metric, helpText := range metricMap[path] {
-			newMetric := newLustreProcMetric(metric, "OST", path, helpText)
+		for _, item := range metricMap[path] {
+			newMetric := newLustreProcMetric(item.filename, "OST", path, item.helpText)
 			s.lustreProcMetrics = append(s.lustreProcMetrics, newMetric)
 		}
 	}
@@ -133,9 +139,9 @@ func (s *lustreSource) generateOSTMetricTemplates() error {
 }
 
 func (s *lustreSource) generateMDTMetricTemplates() error {
-	metricMap := map[string]map[string]string{
+	metricMap := map[string][]lustreHelpStruct{
 		"mdt/*": {
-			"num_exports": "Total number of times the pool has been exported",
+			{"num_exports", "num_exports", "Total number of times the pool has been exported"},
 		},
 	}
 	for path := range metricMap {
@@ -148,20 +154,20 @@ func (s *lustreSource) generateMDTMetricTemplates() error {
 }
 
 func (s *lustreSource) generateMGSMetricTemplates() error {
-	metricMap := map[string]map[string]string{
+	metricMap := map[string][]lustreHelpStruct{
 		"mgs/MGS/osd/": {
-			"blocksize":            "Filesystem block size in bytes",
-			"filesfree":            "The number of inodes (objects) available",
-			"filestotal":           "The maximum number of inodes (objects) the filesystem can hold",
-			"kbytesavail":          "Number of kilobytes readily available in the pool",
-			"kbytesfree":           "Number of kilobytes allocated to the pool",
-			"kbytestotal":          "Capacity of the pool in kilobytes",
-			"quota_iused_estimate": "Returns '1' if a valid address is returned within the pool, referencing whether free space can be allocated",
+			{"blocksize", "blocksize", "Filesystem block size in bytes"},
+			{"filesfree", "filesfree", "The number of inodes (objects) available"},
+			{"filestotal", "filestotal", "The maximum number of inodes (objects) the filesystem can hold"},
+			{"kbytesavail", "kbytesavail", "Number of kilobytes readily available in the pool"},
+			{"kbytesfree", "kbytesfree", "Number of kilobytes allocated to the pool"},
+			{"kbytestotal", "kbytestotal", "Capacity of the pool in kilobytes"},
+			{"quota_iused_estimate", "quota_iused_estimate", "Returns '1' if a valid address is returned within the pool, referencing whether free space can be allocated"},
 		},
 	}
 	for path := range metricMap {
-		for metric, helpText := range metricMap[path] {
-			newMetric := newLustreProcMetric(metric, "MGS", path, helpText)
+		for _, item := range metricMap[path] {
+			newMetric := newLustreProcMetric(item.filename, "MGS", path, item.helpText)
 			s.lustreProcMetrics = append(s.lustreProcMetrics, newMetric)
 		}
 	}
@@ -169,20 +175,20 @@ func (s *lustreSource) generateMGSMetricTemplates() error {
 }
 
 func (s *lustreSource) generateMDSMetricTemplates() error {
-	metricMap := map[string]map[string]string{
+	metricMap := map[string][]lustreHelpStruct{
 		"mds/MDS/osd": {
-			"blocksize":            "Filesystem block size in bytes",
-			"filesfree":            "The number of inodes (objects) available",
-			"filestotal":           "The maximum number of inodes (objects) the filesystem can hold",
-			"kbytesavail":          "Number of kilobytes readily available in the pool",
-			"kbytesfree":           "Number of kilobytes allocated to the pool",
-			"kbytestotal":          "Capacity of the pool in kilobytes",
-			"quota_iused_estimate": "Returns '1' if a valid address is returned within the pool, referencing whether free space can be allocated",
+			{"blocksize", "blocksize", "Filesystem block size in bytes"},
+			{"filesfree", "filesfree", "The number of inodes (objects) available"},
+			{"filestotal", "filestotal", "The maximum number of inodes (objects) the filesystem can hold"},
+			{"kbytesavail", "kbytesavail", "Number of kilobytes readily available in the pool"},
+			{"kbytesfree", "kbytesfree", "Number of kilobytes allocated to the pool"},
+			{"kbytestotal", "kbytestotal", "Capacity of the pool in kilobytes"},
+			{"quota_iused_estimate", "quota_iused_estimate", "Returns '1' if a valid address is returned within the pool, referencing whether free space can be allocated"},
 		},
 	}
 	for path := range metricMap {
-		for metric, helpText := range metricMap[path] {
-			newMetric := newLustreProcMetric(metric, "MDS", path, helpText)
+		for _, item := range metricMap[path] {
+			newMetric := newLustreProcMetric(item.filename, "MDS", path, item.helpText)
 			s.lustreProcMetrics = append(s.lustreProcMetrics, newMetric)
 		}
 	}


### PR DESCRIPTION
Now able to directly access metric elements and easily specify a unique Prometheus name at initialization.

Note that I have not yet updated the names to be Prometheus compliant.