### PR TITLE
Skip jobstats metric if they don't exist

### DIFF
--- a/sources/procfs.go
+++ b/sources/procfs.go
@@ -481,6 +481,10 @@ func getJobStatsByOperation(jobBlock string, jobID string, promName string, help
 		setInfoHelp:        {index: 0, pattern: "set_info"},
 		quotactlHelp:       {index: 0, pattern: "quotactl"},
 	}
+	// If the metric isn't located in the map, don't try to parse a value for it.
+	if _, exists := opMap[helpText]; !exists {
+		return nil, nil
+	}
 	pattern := opMap[helpText].pattern
 	opStat := regexCaptureString(pattern+": .*", jobBlock)
 	opNumbers := regexCaptureStrings("[0-9]*.[0-9]+|[0-9]+", opStat)


### PR DESCRIPTION
In case a particular jobstats metric isn't located on a node, skip over
it instead of trying to parse a value, yielding unexpected results.

Signed-Off-By: Robert Clark <robert.d.clark@hpe.com>