### PR TITLE
Makefile improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Editor files #
+################
+*~
+
+/lustre_exporter

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 
 language: go
 go:
-  - 1.8
+  - 1.8.x
   - tip
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,4 @@ before_install:
 
 script:
   - make
-  - go vet
   - golint

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@
 # limitations under the License.
 
 GO              ?= GO15VENDOREXPERIMENT=1 go
-GOPATH          := $(firstword $(subst :, ,$(GOPATH)))
+GOPATH          := $(firstword $(subst :, ,$(shell $(GO) env GOPATH)))
 PROMU           ?= $(GOPATH)/bin/promu
 pkgs            = $(shell $(GO) list ./... | grep -v /vendor/)
 TARGET          ?= lustre_exporter

--- a/Makefile
+++ b/Makefile
@@ -11,16 +11,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-GO     ?= GO15VENDOREXPERIMENT=1 go
-GOPATH := $(firstword $(subst :, ,$(GOPATH)))
-PROMU  ?= $(GOPATH)/bin/promu
-pkgs    = $(shell $(GO) list ./... | grep -v /vendor/)
-TARGET	?= lustre_exporter
+GO              ?= GO15VENDOREXPERIMENT=1 go
+GOPATH          := $(firstword $(subst :, ,$(GOPATH)))
+PROMU           ?= $(GOPATH)/bin/promu
+pkgs            = $(shell $(GO) list ./... | grep -v /vendor/)
+TARGET          ?= lustre_exporter
 
-PREFIX			?= $(shell pwd)
-BIN_DIR			?= $(shell pwd)
+PREFIX          ?= $(shell pwd)
+BIN_DIR         ?= $(shell pwd)
 
-all: format build test
+all: format vet build test
 
 test:
 	@echo ">> running tests"
@@ -29,6 +29,10 @@ test:
 format:
 	@echo ">> formatting code"
 	@$(GO) fmt $(pkgs)
+
+vet:
+	@echo ">> vetting code"
+	@$(GO) vet $(pkgs)
 
 build: $(PROMU)
 	@echo ">> building binaries"
@@ -44,4 +48,4 @@ $(GOPATH)/bin/promu promu:
 		$(GO) get -u github.com/prometheus/promu
 
 
-.PHONY: all format build test promu clean $(GOPATH)/bin/promu
+.PHONY: all format vet build test promu clean $(GOPATH)/bin/promu

--- a/README.md
+++ b/README.md
@@ -7,17 +7,23 @@
 
 ## Getting
 
+```
 go get github.com/HewlettPackard/lustre_exporter
+```
 
 ## Building
 
-cd $GOPATH/src/github.com/HewlettPackard/lustre_exporter
 
+```
+cd $GOPATH/src/github.com/HewlettPackard/lustre_exporter
 make
+```
 
 ## Running
 
+```
 ./lustre_exporter
+```
 
 ### Flags
 
@@ -37,7 +43,7 @@ Design plans
     - STATUS: We have some of this via the 'brw_stats' file. We have created the histograms within Grafana in early tests.
   - Other data sources (CLI data that isn't present in /proc, for example). Users will be able to disable non-proc sources via a configuration flag.
     - STATUS: Not yet started
-    
+
 ## Contributing
 
 To contribute to this HPE project, you'll need to fill out a CLA (Contributor License Agreement). If you would like to contribute anything more than a bug fix (feature, architectural change, etc), please file an issue and we'll get in touch with you to have you fill out the CLA. 


### PR DESCRIPTION
I made some small aesthetic changes to the [Makefile](Makefile) and fix also a `vet` warning,
```
>> formatting code
>> vetting code
lustre_exporter.go:60: range variable c captured by func literal
exit status 1
Makefile:35: recipe for target 'vet' failed
make: *** [vet] Error 1
```
In addition I create a (.gitignore)(gitignore) file to exclude ***~** and the binary created **lustre_exporter**.

I hope you agree with the changes. Thanks!