### PR TITLE
Fix range variable c captured by func literal

### DIFF
--- a/lustre_exporter.go
+++ b/lustre_exporter.go
@@ -56,7 +56,7 @@ func (l LustreSource) Collect(ch chan<- prometheus.Metric) {
 	wg := sync.WaitGroup{}
 	wg.Add(len(l.sourceList))
 	for name, c := range l.sourceList {
-		go func(name string, s sources.LustreSource) {
+		go func(name string, c sources.LustreSource) {
 			collectFromSource(name, c, ch)
 			wg.Done()
 		}(name, c)


### PR DESCRIPTION
Hi @joehandzik, I am fixing this bug reported by go vet, and related to the changes in #61.

```
$ make 
>> formatting code
>> vetting code
lustre_exporter.go:60: range variable c captured by func literal
exit status 1
Makefile:34: recipe for target 'vet' failed
make: *** [vet] Error 1
``` 
As explanation I can refer you [this](https://github.com/gnhuy91/til/issues/7). Thanks @knweiss!
