### PR TITLE
Skip empty jobstats

### DIFF
--- a/sources/procfs.go
+++ b/sources/procfs.go
@@ -497,6 +497,9 @@ func getJobStatsByOperation(jobBlock string, jobID string, promName string, help
 	pattern := opMap[helpText].pattern
 	opStat := regexCaptureString(pattern+": .*", jobBlock)
 	opNumbers := regexCaptureStrings("[0-9]*.[0-9]+|[0-9]+", opStat)
+	if len(opNumbers) < 1 {
+		return nil, nil
+	}
 	result, err := strconv.ParseUint(strings.TrimSpace(opNumbers[opMap[helpText].index]), 10, 64)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
In some situations, a metric that is being queried by the lustre_exporter
might not be tracked in the job_stats file and can cause GO to panic.
This update skips over any metrics that don't provide valid responses.

Signed-Off-By: Robert Clark <robert.d.clark@hpe.com>