### PR TITLE
Update float parsing patterns

### DIFF
--- a/sources/procfs.go
+++ b/sources/procfs.go
@@ -574,7 +574,7 @@ func getJobStatsByOperation(jobBlock string, jobID string, promName string, help
 	}
 	pattern := opMap[helpText].pattern
 	opStat := regexCaptureString(pattern+": .*", jobBlock)
-	opNumbers := regexCaptureStrings("[0-9]*.[0-9]+|[0-9]+", opStat)
+	opNumbers := regexCaptureStrings("[0-9]*\\.[0-9]+|[0-9]+", opStat)
 	if len(opNumbers) < 1 {
 		return nil, nil
 	}
@@ -594,7 +594,7 @@ func getJobStatsByOperation(jobBlock string, jobID string, promName string, help
 
 func getJobNum(jobBlock string) (jobID string, err error) {
 	jobID = regexCaptureString("job_id: .*", jobBlock)
-	jobID = regexCaptureString("[0-9]*.[0-9]+|[0-9]+", jobID)
+	jobID = regexCaptureString("[0-9]*\\.[0-9]+|[0-9]+", jobID)
 	return strings.Trim(jobID, " "), nil
 }
 

--- a/sources/procfs_test.go
+++ b/sources/procfs_test.go
@@ -60,7 +60,7 @@ Currently, Lustre is on over 60% of the top supercomputers in the world.`
 
 func TestRegexCaptureString(t *testing.T) {
 	testString := "Hex Dump: 42 4F 49 4C 45 52 20 55 50"
-	testPattern := "[0-9]*.[0-9]+|[0-9]+"
+	testPattern := "[0-9]*\\.[0-9]+|[0-9]+"
 	expected := "42"
 
 	matchedString := strings.TrimSpace(regexCaptureString(testPattern, testString))


### PR DESCRIPTION
Previously, the regex matcher intended to match floats, but would
instead match any character between two numbers as opposed to a
period. For example, the numbers '1965 1966' would be parsed as a
single string ('1965 1966') instead of two strings ('1965' '1966').
This update now properly parses both floats and integers.

Signed-Off-By: Robert Clark <robert.d.clark@hpe.com>