### PR TITLE
Add Megacheck

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ go:
 
 before_install:
   - go get github.com/golang/lint/golint
+  - go get honnef.co/go/tools/cmd/megacheck
 
 script:
   - make

--- a/Makefile
+++ b/Makefile
@@ -14,13 +14,14 @@
 GO              ?= GO15VENDOREXPERIMENT=1 go
 GOPATH          := $(firstword $(subst :, ,$(shell $(GO) env GOPATH)))
 PROMU           ?= $(GOPATH)/bin/promu
+MEGACHECK       ?= $(GOPATH)/bin/megacheck
 pkgs            = $(shell $(GO) list ./... | grep -v /vendor/)
 TARGET          ?= lustre_exporter
 
 PREFIX          ?= $(shell pwd)
 BIN_DIR         ?= $(shell pwd)
 
-all: format vet build test
+all: format vet megacheck build test
 
 test:
 	@echo ">> running tests"
@@ -33,6 +34,10 @@ format:
 vet:
 	@echo ">> vetting code"
 	@$(GO) vet $(pkgs)
+
+megacheck:
+	@echo ">> megacheck code"
+	@$(MEGACHECK) $(pkgs)
 
 build: $(PROMU)
 	@echo ">> building binaries"
@@ -47,5 +52,9 @@ $(GOPATH)/bin/promu promu:
 		GOARCH=$(subst x86_64,amd64,$(patsubst i%86,386,$(shell uname -m))) \
 		$(GO) get -u github.com/prometheus/promu
 
+$(GOPATH)/bin/megacheck mega:
+	@GOOS=$(shell uname -s | tr A-Z a-z) \
+		GOARCH=$(subst x86_64,amd64,$(patsubst i%86,386,$(shell uname -m))) \
+		$(GO) get -u honnef.co/go/tools/cmd/megacheck
 
-.PHONY: all format vet build test promu clean $(GOPATH)/bin/promu
+.PHONY: all format vet mega build test promu clean $(GOPATH)/bin/promu $(GOPATH)/bin/megacheck


### PR DESCRIPTION
Hi,
I just found [megacheck](https://github.com/dominikh/go-tools/tree/master/cmd/megacheck) as a part of the [go-tools](https://github.com/dominikh/go-tools) project and wanted to give it a try. 

As you can see above, this seems to be worth. 

```
$ make
>> formatting code
>> vetting code
>> megacheck code
sources/procfs.go:84:2: field subsystem is unused (U1000)
sources/procfs.go:534:3: should replace loop with metricList = append(metricList, statsList...) (S1011)
sources/procfs.go:623:3: should replace loop with metricList = append(metricList, jobList...) (S1011)
sources/procfs.go:714:22: this value of err is never used (SA4006)
sources/procfs_test.go:207:2: this value of metricList is never used (SA4006)
sources/source.go:31:6: type typedDesc is unused (U1000)
Makefile:39: recipe for target 'megacheck' failed
make: *** [megacheck] Error 1
```

See also, 
  - [gosimple#checks](https://github.com/dominikh/go-tools/tree/master/cmd/gosimple#checks)
  - [staticcheck#checks](https://github.com/dominikh/go-tools/tree/master/cmd/staticcheck#checks)

This could be integrated to the project, of course after resolving the issues, if you are interested.
