### PR TITLE
Move all number parsing to separate function

### DIFF
--- a/sources/proc_common.go
+++ b/sources/proc_common.go
@@ -23,6 +23,10 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
+var (
+	numRegexPattern = regexp.MustCompile(`[0-9]*\.[0-9]+|[0-9]+`)
+)
+
 type prometheusType func([]string, []string, string, string, uint64) prometheus.Metric
 
 type lustreProcMetric struct {
@@ -77,6 +81,11 @@ func regexCaptureStrings(pattern string, textToMatch string) (matchedStrings []s
 	re := regexp.MustCompile(pattern)
 	matchedStrings = re.FindAllString(textToMatch, -1)
 	return matchedStrings
+}
+
+func regexCaptureNumbers(textToMatch string) (matchedNumbers []string) {
+	matchedNumbers = numRegexPattern.FindAllString(textToMatch, -1)
+	return matchedNumbers
 }
 
 func parseFileElements(path string, directoryDepth int) (name string, nodeName string, err error) {

--- a/sources/procfs.go
+++ b/sources/procfs.go
@@ -506,7 +506,7 @@ func getJobStatsIOMetrics(jobBlock string, jobID string, promName string, helpTe
 	}
 	pattern := opMap[helpText].pattern
 	opStat := regexCaptureString(pattern+": .*", jobBlock)
-	opNumbers := regexCaptureStrings("[0-9]*\\.[0-9]+|[0-9]+", opStat)
+	opNumbers := regexCaptureNumbers(opStat)
 	if len(opNumbers) < 1 {
 		return nil, nil
 	}
@@ -528,8 +528,11 @@ func getJobStatsIOMetrics(jobBlock string, jobID string, promName string, helpTe
 
 func getJobNum(jobBlock string) (jobID string, err error) {
 	jobID = regexCaptureString("job_id: .*", jobBlock)
-	jobID = regexCaptureString("[0-9]*\\.[0-9]+|[0-9]+", jobID)
-	return strings.Trim(jobID, " "), nil
+	jobIDlist := regexCaptureNumbers(jobID)
+	if len(jobIDlist) < 1 {
+		return "", nil
+	}
+	return strings.Trim(jobIDlist[0], " "), nil
 }
 
 func getJobStatsOperationMetrics(jobBlock string, jobID string, promName string, helpText string) (metricList []lustreJobsMetric, err error) {

--- a/sources/procsys.go
+++ b/sources/procsys.go
@@ -136,7 +136,7 @@ func parseSysStatsFile(helpText string, promName string, statsFile string) (metr
 		lnetRouteLengthHelp:   9,
 		lnetDropLengthHelp:    10,
 	}
-	statsResults := regexCaptureStrings("[0-9]*\\.[0-9]+|[0-9]+", statsFile)
+	statsResults := regexCaptureNumbers(statsFile)
 	if len(statsResults) < 1 {
 		return metric, nil
 	}


### PR DESCRIPTION
The global initialization of the number regex parser reduces the total
number of mallocs by a factor of approximately 10.

Signed-Off-By: Robert Clark <robert.d.clark@hpe.com>