### PR TITLE
Replace 'max wait time' with 'out of mem'

### DIFF
--- a/lustre_exporter_test.go
+++ b/lustre_exporter_test.go
@@ -1260,6 +1260,7 @@ func TestCollector(t *testing.T) {
 		{"lustre_grows_failure_total", "Total number of failures while attempting to add pages.", counter, []labelPair{{"Generic", "sptlrpc"}}, 0, false},
 		{"lustre_shrinks_total", "Total number of shrinks.", counter, []labelPair{{"Generic", "sptlrpc"}}, 0, false},
 		{"lustre_free_page_low", "Lowest number of free pages reached.", gauge, []labelPair{{"Generic", "sptlrpc"}}, 0, false},
+		{"lustre_out_of_memory_request_total", "Total number of out of memory requests.", 0, []labelPair{{"Generic", "sptlrpc"}}, 0, false},
 
 		// LNET Metrics
 		{"lustre_console_max_delay_centiseconds", "Minimum time in centiseconds before the console logs a message", gauge, []labelPair{{"lnet", "lnet"}}, 60000, false},

--- a/sources/procfs.go
+++ b/sources/procfs.go
@@ -63,7 +63,6 @@ const (
 	cacheMissingHelp      string = "Total number of cache misses."
 	lowFreeMarkHelp       string = "Lowest number of free pages reached."
 	maxWaitQueueDepthHelp string = "Maximum waitqueue length."
-	maxWaitTimeHelp       string = "Maximum wait time in jiffies."
 	outOfMemHelp          string = "Total number of out of memory requests."
 
 	// string mappings for 'health_check' values
@@ -311,7 +310,6 @@ func (s *lustreProcfsSource) generateGenericMetricTemplates() {
 			{"encrypt_page_pools", "cache_miss_total", cacheMissingHelp, s.counterMetric, false},
 			{"encrypt_page_pools", "free_page_low", lowFreeMarkHelp, s.gaugeMetric, false},
 			{"encrypt_page_pools", "maximum_waitqueue_depth", maxWaitQueueDepthHelp, s.gaugeMetric, false},
-			{"encrypt_page_pools", "maximum_wait_time_jiffies", maxWaitTimeHelp, s.gaugeMetric, false},
 			{"encrypt_page_pools", "out_of_memory_request_total", outOfMemHelp, s.counterMetric, false},
 		},
 	}
@@ -492,7 +490,6 @@ func getStatsIOMetrics(statsFile string, promName string, helpText string) (metr
 		cacheMissingHelp:      {pattern: "cache missing: .*", index: 2},
 		lowFreeMarkHelp:       {pattern: "low free mark: .*", index: 3},
 		maxWaitQueueDepthHelp: {pattern: "max waitqueue depth: .*", index: 3},
-		maxWaitTimeHelp:       {pattern: "max wait time: .*", index: 3},
 		outOfMemHelp:          {pattern: "out of mem: .*", index: 3},
 	}
 	pattern := bytesMap[helpText].pattern


### PR DESCRIPTION
The 'max wait time' metric is a fractional value which cannot be parsed
as a float and in-turn can't be used with Prometheus. Instead,
re-capture the 'out of mem' metric.

Signed-Off-By: Robert Clark <robert.d.clark@hpe.com>