### PR TITLE
Use float64 instead of uint64 for all Prom metrics

### DIFF
--- a/sources/proc_common.go
+++ b/sources/proc_common.go
@@ -27,7 +27,7 @@ var (
 	numRegexPattern = regexp.MustCompile(`[0-9]*\.[0-9]+|[0-9]+`)
 )
 
-type prometheusType func([]string, []string, string, string, uint64) prometheus.Metric
+type prometheusType func([]string, []string, string, string, float64) prometheus.Metric
 
 type lustreProcMetric struct {
 	filename        string
@@ -42,7 +42,7 @@ type lustreProcMetric struct {
 type lustreStatsMetric struct {
 	title           string
 	help            string
-	value           uint64
+	value           float64
 	extraLabel      string
 	extraLabelValue string
 }

--- a/sources/procfs_test.go
+++ b/sources/procfs_test.go
@@ -59,7 +59,7 @@ func TestGetJobStats(t *testing.T) {
 	testJobID := "29"
 	testPromName := "job_write_bytes_total"
 	testHelpText := writeTotalHelp
-	expected := uint64(274726912)
+	expected := float64(274726912)
 
 	metricList, err := getJobStatsIOMetrics(testJobBlock, testJobID, testPromName, testHelpText)
 	if err != nil {
@@ -69,7 +69,7 @@ func TestGetJobStats(t *testing.T) {
 		t.Fatalf("Retrieved an unexpected number of items. Expected: %d, Got: %d", 1, l)
 	}
 	if metricList[0].value != expected {
-		t.Fatalf("Retrieved an unexpected value. Expected: %d, Got: %d", expected, metricList[0].value)
+		t.Fatalf("Retrieved an unexpected value. Expected: %f, Got: %f", expected, metricList[0].value)
 	}
 	if metricList[0].help != writeTotalHelp {
 		t.Fatal("Retrieved an unexpected help text.")
@@ -88,8 +88,8 @@ func TestGetJobStats(t *testing.T) {
 	if l := len(metricList); l != 10 {
 		t.Fatalf("Retrieved an unexpected number of items. Expected: %d, Got: %d", 1, l)
 	}
-	if metricList[9].value != 10 {
-		t.Fatalf("Retrieved an unexpected value. Expected: %d, Got: %d", 10, metricList[9].value)
+	if metricList[9].value != float64(10) {
+		t.Fatalf("Retrieved an unexpected value. Expected: %f, Got: %f", float64(10), metricList[9].value)
 	}
 	if metricList[3].help != jobStatsHelp {
 		t.Fatal("Retrieved an unexpected help text.")

--- a/sources/procsys.go
+++ b/sources/procsys.go
@@ -112,7 +112,7 @@ func (s *lustreProcsysSource) Update(ch chan<- prometheus.Metric) (err error) {
 			if metric.filename == stats {
 				metricType = stats
 			}
-			err = s.parseFile(metric.source, metricType, path, metric.helpText, metric.promName, func(nodeType string, nodeName string, name string, helpText string, value uint64) {
+			err = s.parseFile(metric.source, metricType, path, metric.helpText, metric.promName, func(nodeType string, nodeName string, name string, helpText string, value float64) {
 				ch <- metric.metricFunc([]string{nodeType}, []string{nodeName}, name, helpText, value)
 			})
 			if err != nil {
@@ -146,7 +146,7 @@ func parseSysStatsFile(helpText string, promName string, statsFile string) (metr
 		return metric, nil
 	}
 	index := statsMap[helpText]
-	value, err := strconv.ParseUint(statsResults[index], 10, 64)
+	value, err := strconv.ParseFloat(statsResults[index], 64)
 	if err != nil {
 		return metric, err
 	}
@@ -158,7 +158,7 @@ func parseSysStatsFile(helpText string, promName string, statsFile string) (metr
 	return metric, nil
 }
 
-func (s *lustreProcsysSource) parseFile(nodeType string, metricType string, path string, helpText string, promName string, handler func(string, string, string, string, uint64)) (err error) {
+func (s *lustreProcsysSource) parseFile(nodeType string, metricType string, path string, helpText string, promName string, handler func(string, string, string, string, float64)) (err error) {
 	_, nodeName, err := parseFileElements(path, 0)
 	if err != nil {
 		return err
@@ -169,7 +169,7 @@ func (s *lustreProcsysSource) parseFile(nodeType string, metricType string, path
 		if err != nil {
 			return err
 		}
-		convertedValue, err := strconv.ParseUint(strings.TrimSpace(string(value)), 10, 64)
+		convertedValue, err := strconv.ParseFloat(strings.TrimSpace(string(value)), 64)
 		if err != nil {
 			return err
 		}
@@ -189,7 +189,7 @@ func (s *lustreProcsysSource) parseFile(nodeType string, metricType string, path
 	return nil
 }
 
-func (s *lustreProcsysSource) counterMetric(labels []string, labelValues []string, name string, helpText string, value uint64) prometheus.Metric {
+func (s *lustreProcsysSource) counterMetric(labels []string, labelValues []string, name string, helpText string, value float64) prometheus.Metric {
 	return prometheus.MustNewConstMetric(
 		prometheus.NewDesc(
 			prometheus.BuildFQName(Namespace, "", name),
@@ -198,12 +198,12 @@ func (s *lustreProcsysSource) counterMetric(labels []string, labelValues []strin
 			nil,
 		),
 		prometheus.CounterValue,
-		float64(value),
+		value,
 		labelValues...,
 	)
 }
 
-func (s *lustreProcsysSource) gaugeMetric(labels []string, labelValues []string, name string, helpText string, value uint64) prometheus.Metric {
+func (s *lustreProcsysSource) gaugeMetric(labels []string, labelValues []string, name string, helpText string, value float64) prometheus.Metric {
 	return prometheus.MustNewConstMetric(
 		prometheus.NewDesc(
 			prometheus.BuildFQName(Namespace, "", name),
@@ -212,7 +212,7 @@ func (s *lustreProcsysSource) gaugeMetric(labels []string, labelValues []string,
 			nil,
 		),
 		prometheus.GaugeValue,
-		float64(value),
+		value,
 		labelValues...,
 	)
 }


### PR DESCRIPTION
For any possible metric value, always assume the value could require being parsed as a floating point value. This has the positive side-effect of eliminating some conversions to float64 across the codebase.

Fixes issue #111.

Signed-Off-By: Joe Handzik <joseph.t.handzik@hpe.com>