### PR TITLE
Change flag behavior to introduce metric priority levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,15 +27,32 @@ make
 
 ### Flags
 
-Boolean (True/False)
+* collector.ost=disabled/core/extended
+* collector.mdt=disabled/core/extended
+* collector.mgs=disabled/core/extended
+* collector.mds=disabled/core/extended
+* collector.client=disabled/core/extended
+* collector.generic=disabled/core/extended
+* collector.lnet=disabled/core/extended
 
-* collector.ost - Enable OST metrics
-* collector.mdt - Enable MDT metrics
-* collector.mgs - Enable MGS metrics
-* collector.mds - Enable MDS metrics
-* collector.client - Enable client metrics
-* collector.generic - Enable generic metrics
-* collector.lnet - Enable lnet metrics
+All above flags default to the value "extended" when no argument is submitted by the user.
+
+Example: `./lustre_exporter -collector.ost=disabled -collector.mdt=core -collector.mgs=extended`
+
+The above example will result in a running instance of the Lustre Exporter with the following statuses:
+* collector.ost=disabled
+* collector.mdt=core
+* collector.mgs=extended
+* collector.mds=extended
+* collector.client=extended
+* collector.generic=extended
+* collector.lnet=extended
+
+Flag Option Detailed Description
+
+- disabled - Completely disable all metrics for this portion of a source.
+- core - Enable this source, but only for metrics considered to be particularly useful.
+- extended - Enable this source and include all metrics that the Lustre Exporter is aware of within it.
 
 ## What's exported?
 

--- a/lustre_exporter.go
+++ b/lustre_exporter.go
@@ -100,13 +100,13 @@ func main() {
 		showVersion    = flag.Bool("version", false, "Print version information.")
 		listenAddress  = flag.String("web.listen-address", ":9169", "Address to use to expose Lustre metrics.")
 		metricsPath    = flag.String("web.telemetry-path", "/metrics", "Path to use to expose Lustre metrics.")
-		ostEnabled     = flag.Bool("collector.ost", true, "Enable OST metrics")
-		mdtEnabled     = flag.Bool("collector.mdt", true, "Enable MDT metrics")
-		mgsEnabled     = flag.Bool("collector.mgs", true, "Enable MGS metrics")
-		mdsEnabled     = flag.Bool("collector.mds", true, "Enable MDS metrics")
-		clientEnabled  = flag.Bool("collector.client", true, "Enable Client metrics")
-		genericEnabled = flag.Bool("collector.generic", true, "Enable Generic metrics")
-		lnetEnabled    = flag.Bool("collector.lnet", true, "Enable LNET metrics")
+		ostEnabled     = flag.String("collector.ost", "extended", "Enable OST metrics")
+		mdtEnabled     = flag.String("collector.mdt", "extended", "Enable MDT metrics")
+		mgsEnabled     = flag.String("collector.mgs", "extended", "Enable MGS metrics")
+		mdsEnabled     = flag.String("collector.mds", "extended", "Enable MDS metrics")
+		clientEnabled  = flag.String("collector.client", "extended", "Enable Client metrics")
+		genericEnabled = flag.String("collector.generic", "extended", "Enable Generic metrics")
+		lnetEnabled    = flag.String("collector.lnet", "extended", "Enable LNET metrics")
 	)
 	flag.Parse()
 
@@ -123,33 +123,19 @@ func main() {
 
 	log.Infof("Enabled Components:")
 	sources.OstEnabled = *ostEnabled
-	if sources.OstEnabled {
-		log.Infof(" - OST Enabled")
-	}
+	log.Infof(" - OST State: %s", sources.OstEnabled)
 	sources.MdtEnabled = *mdtEnabled
-	if sources.MdtEnabled {
-		log.Infof(" - MDT Enabled")
-	}
+	log.Infof(" - MDT State: %s", sources.MdtEnabled)
 	sources.MgsEnabled = *mgsEnabled
-	if sources.MgsEnabled {
-		log.Infof(" - MGS Enabled")
-	}
+	log.Infof(" - MGS State: %s", sources.MgsEnabled)
 	sources.MdsEnabled = *mdsEnabled
-	if sources.MdsEnabled {
-		log.Infof(" - MDS Enabled")
-	}
+	log.Infof(" - MDS State: %s", sources.MdsEnabled)
 	sources.ClientEnabled = *clientEnabled
-	if sources.ClientEnabled {
-		log.Infof(" - Client Enabled")
-	}
+	log.Infof(" - Client State: %s", sources.ClientEnabled)
 	sources.GenericEnabled = *genericEnabled
-	if sources.GenericEnabled {
-		log.Infof(" - Generic Enabled")
-	}
+	log.Infof(" - Generic State: %s", sources.GenericEnabled)
 	sources.LnetEnabled = *lnetEnabled
-	if sources.LnetEnabled {
-		log.Infof(" - Lnet Enabled")
-	}
+	log.Infof(" - Lnet State: %s", sources.LnetEnabled)
 
 	enabledSources := []string{"procfs", "procsys"}
 

--- a/lustre_exporter_test.go
+++ b/lustre_exporter_test.go
@@ -56,61 +56,61 @@ var (
 func toggleCollectors(target string) {
 	switch target {
 	case "OST":
-		sources.OstEnabled = true
-		sources.MdtEnabled = false
-		sources.MgsEnabled = false
-		sources.MdsEnabled = false
-		sources.ClientEnabled = false
-		sources.GenericEnabled = false
-		sources.LnetEnabled = false
+		sources.OstEnabled = "extended"
+		sources.MdtEnabled = "disabled"
+		sources.MgsEnabled = "disabled"
+		sources.MdsEnabled = "disabled"
+		sources.ClientEnabled = "disabled"
+		sources.GenericEnabled = "disabled"
+		sources.LnetEnabled = "disabled"
 	case "MDT":
-		sources.OstEnabled = false
-		sources.MdtEnabled = true
-		sources.MgsEnabled = false
-		sources.MdsEnabled = false
-		sources.ClientEnabled = false
-		sources.GenericEnabled = false
-		sources.LnetEnabled = false
+		sources.OstEnabled = "disabled"
+		sources.MdtEnabled = "extended"
+		sources.MgsEnabled = "disabled"
+		sources.MdsEnabled = "disabled"
+		sources.ClientEnabled = "disabled"
+		sources.GenericEnabled = "disabled"
+		sources.LnetEnabled = "disabled"
 	case "MGS":
-		sources.OstEnabled = false
-		sources.MdtEnabled = false
-		sources.MgsEnabled = true
-		sources.MdsEnabled = false
-		sources.ClientEnabled = false
-		sources.GenericEnabled = false
-		sources.LnetEnabled = false
+		sources.OstEnabled = "disabled"
+		sources.MdtEnabled = "disabled"
+		sources.MgsEnabled = "extended"
+		sources.MdsEnabled = "disabled"
+		sources.ClientEnabled = "disabled"
+		sources.GenericEnabled = "disabled"
+		sources.LnetEnabled = "disabled"
 	case "MDS":
-		sources.OstEnabled = false
-		sources.MdtEnabled = false
-		sources.MgsEnabled = false
-		sources.MdsEnabled = true
-		sources.ClientEnabled = false
-		sources.GenericEnabled = false
-		sources.LnetEnabled = false
+		sources.OstEnabled = "disabled"
+		sources.MdtEnabled = "disabled"
+		sources.MgsEnabled = "disabled"
+		sources.MdsEnabled = "extended"
+		sources.ClientEnabled = "disabled"
+		sources.GenericEnabled = "disabled"
+		sources.LnetEnabled = "disabled"
 	case "Client":
-		sources.OstEnabled = false
-		sources.MdtEnabled = false
-		sources.MgsEnabled = false
-		sources.MdsEnabled = false
-		sources.ClientEnabled = true
-		sources.GenericEnabled = false
-		sources.LnetEnabled = false
+		sources.OstEnabled = "disabled"
+		sources.MdtEnabled = "disabled"
+		sources.MgsEnabled = "disabled"
+		sources.MdsEnabled = "disabled"
+		sources.ClientEnabled = "extended"
+		sources.GenericEnabled = "disabled"
+		sources.LnetEnabled = "disabled"
 	case "Generic":
-		sources.OstEnabled = false
-		sources.MdtEnabled = false
-		sources.MgsEnabled = false
-		sources.MdsEnabled = false
-		sources.ClientEnabled = false
-		sources.GenericEnabled = true
-		sources.LnetEnabled = false
+		sources.OstEnabled = "disabled"
+		sources.MdtEnabled = "disabled"
+		sources.MgsEnabled = "disabled"
+		sources.MdsEnabled = "disabled"
+		sources.ClientEnabled = "disabled"
+		sources.GenericEnabled = "extended"
+		sources.LnetEnabled = "disabled"
 	case "LNET":
-		sources.OstEnabled = false
-		sources.MdtEnabled = false
-		sources.MgsEnabled = false
-		sources.MdsEnabled = false
-		sources.ClientEnabled = false
-		sources.GenericEnabled = false
-		sources.LnetEnabled = true
+		sources.OstEnabled = "disabled"
+		sources.MdtEnabled = "disabled"
+		sources.MgsEnabled = "disabled"
+		sources.MdsEnabled = "disabled"
+		sources.ClientEnabled = "disabled"
+		sources.GenericEnabled = "disabled"
+		sources.LnetEnabled = "extended"
 	}
 }
 

--- a/sources/proc_common.go
+++ b/sources/proc_common.go
@@ -23,6 +23,12 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
+const (
+	core     string = "core"
+	extended string = "extended"
+	disabled string = "disabled"
+)
+
 var (
 	numRegexPattern = regexp.MustCompile(`[0-9]*\.[0-9]+|[0-9]+`)
 )
@@ -53,6 +59,7 @@ type lustreHelpStruct struct {
 	helpText        string
 	metricFunc      prometheusType
 	hasMultipleVals bool
+	priorityLevel   string
 }
 
 func newLustreProcMetric(filename string, promName string, source string, path string, helpText string, hasMultipleVals bool, metricFunc prometheusType) lustreProcMetric {


### PR DESCRIPTION
Change flags from binary to string arguments, and introduce the concept of disabled, core, and extended.

Signed-Off-By: Joe Handzik <joseph.t.handzik@hpe.com>

Fixes issue #116.