### PR TITLE
Fix job id missing process name

### DIFF
--- a/sources/proc_common.go
+++ b/sources/proc_common.go
@@ -30,7 +30,8 @@ const (
 )
 
 var (
-	numRegexPattern = regexp.MustCompile(`[0-9]*\.[0-9]+|[0-9]+`)
+	numRegexPattern   = regexp.MustCompile(`[0-9]*\.[0-9]+|[0-9]+`)
+	jobidRegexPattern = regexp.MustCompile(`job_id:\s*(.*\.[0-9]+|[0-9_]+)`)
 )
 
 type prometheusType func([]string, []string, string, string, float64) prometheus.Metric
@@ -93,6 +94,11 @@ func regexCaptureStrings(pattern string, textToMatch string) (matchedStrings []s
 func regexCaptureNumbers(textToMatch string) (matchedNumbers []string) {
 	matchedNumbers = numRegexPattern.FindAllString(textToMatch, -1)
 	return matchedNumbers
+}
+
+func regexCaptureJobids(textToMatch string) (matchedJobids []string) {
+	matchedJobids = jobidRegexPattern.FindStringSubmatch(textToMatch)
+	return
 }
 
 func parseFileElements(path string, directoryDepth int) (name string, nodeName string, err error) {

--- a/sources/procfs.go
+++ b/sources/procfs.go
@@ -606,11 +606,11 @@ func getJobStatsIOMetrics(jobBlock string, jobID string, promName string, helpTe
 
 func getJobNum(jobBlock string) (jobID string, err error) {
 	jobID = regexCaptureString("job_id: .*", jobBlock)
-	jobIDlist := regexCaptureNumbers(jobID)
-	if len(jobIDlist) < 1 {
+	matched := regexCaptureJobids(jobID)
+	if len(matched) < 2 {
 		return "", nil
 	}
-	return strings.Trim(jobIDlist[0], " "), nil
+	return matched[1], nil
 }
 
 func getJobStatsOperationMetrics(jobBlock string, jobID string, promName string, helpText string) (metricList []lustreJobsMetric, err error) {
@@ -662,7 +662,7 @@ func getJobStatsOperationMetrics(jobBlock string, jobID string, promName string,
 }
 
 func parseJobStatsText(jobStats string, promName string, helpText string, hasMultipleVals bool) (metricList []lustreJobsMetric, err error) {
-	jobs := regexCaptureStrings("(?ms:job_id:.*?(-|\\z))", jobStats)
+	jobs := regexCaptureStrings("(?ms:job_id:.*?$.*?(-|\\z))", jobStats)
 	if len(jobs) < 1 {
 		return nil, nil
 	}

--- a/sources/procfs.go
+++ b/sources/procfs.go
@@ -543,7 +543,7 @@ func splitBRWStats(statBlock string) (metricList []lustreBRWMetric, err error) {
 }
 
 func parseStatsFile(helpText string, promName string, path string, hasMultipleVals bool) (metricList []lustreStatsMetric, err error) {
-	statsFileBytes, err := ioutil.ReadFile(path)
+	statsFileBytes, err := ioutil.ReadFile(filepath.Clean(path))
 	if err != nil {
 		return nil, err
 	}
@@ -692,7 +692,7 @@ func (s *lustreProcfsSource) parseJobStats(nodeType string, metricType string, p
 	if err != nil {
 		return err
 	}
-	jobStatsBytes, err := ioutil.ReadFile(path)
+	jobStatsBytes, err := ioutil.ReadFile(filepath.Clean(path))
 	if err != nil {
 		return err
 	}
@@ -725,7 +725,7 @@ func (s *lustreProcfsSource) parseBRWStats(nodeType string, metricType string, p
 		rpcsInFlightHelp:       "rpcs in flight",
 		offsetHelp:             "offset",
 	}
-	statsFileBytes, err := ioutil.ReadFile(path)
+	statsFileBytes, err := ioutil.ReadFile(filepath.Clean(path))
 	if err != nil {
 		return err
 	}
@@ -759,7 +759,7 @@ func (s *lustreProcfsSource) parseFile(nodeType string, metricType string, path 
 	}
 	switch metricType {
 	case single:
-		value, err := ioutil.ReadFile(path)
+		value, err := ioutil.ReadFile(filepath.Clean(path))
 		if err != nil {
 			return err
 		}

--- a/sources/procfs_test.go
+++ b/sources/procfs_test.go
@@ -39,6 +39,17 @@ func TestGetJobNum(t *testing.T) {
 	if jobID != expected {
 		t.Fatalf("Retrieved an unexpected Job ID. Expected: %s, Got: %s", expected, jobID)
 	}
+
+	testString = "job_id:  abc .0123 .-_+ AB.1000  "
+	expected = "abc .0123 .-_+ AB.1000"
+
+	jobID, err = getJobNum(testString)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if jobID != expected {
+		t.Fatalf("Retrieved an unexpected Job ID. Expected: %s, Got: %s", expected, jobID)
+	}
 }
 
 func TestGetJobStats(t *testing.T) {

--- a/sources/procsys.go
+++ b/sources/procsys.go
@@ -167,7 +167,7 @@ func (s *lustreProcsysSource) parseFile(nodeType string, metricType string, path
 	}
 	switch metricType {
 	case single:
-		value, err := ioutil.ReadFile(path)
+		value, err := ioutil.ReadFile(filepath.Clean(path))
 		if err != nil {
 			return err
 		}
@@ -177,7 +177,7 @@ func (s *lustreProcsysSource) parseFile(nodeType string, metricType string, path
 		}
 		handler(nodeType, nodeName, promName, helpText, convertedValue)
 	case stats:
-		statsFileBytes, err := ioutil.ReadFile(path)
+		statsFileBytes, err := ioutil.ReadFile(filepath.Clean(path))
 		if err != nil {
 			return err
 		}

--- a/sources/sysfs.go
+++ b/sources/sysfs.go
@@ -99,7 +99,7 @@ func (s *lustreSysSource) parseTextFile(nodeType string, metricType string, path
 	if err != nil {
 		return err
 	}
-	fileBytes, err := ioutil.ReadFile(path)
+	fileBytes, err := ioutil.ReadFile(filepath.Clean(path))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
When enable `jobid_var = procname_uid` in lustre, the lustre client also collect job id like `<process_name>.<uid>` .

The current lustre_exporter implement has missing to handle process name in job id, which also cause the issue #135